### PR TITLE
Fixing cast_op_type

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -52,7 +52,7 @@ template <typename type> using make_caster = type_caster<intrinsic_t<type>>;
 
 // Shortcut for calling a caster's `cast_op_type` cast operator for casting a type_caster to a T
 template <typename T> typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
-    return caster.operator typename make_caster<T>::template cast_op_type<T>();
+    return caster.operator typename make_caster<T>::template cast_op_type();
 }
 template <typename T> typename make_caster<T>::template cast_op_type<typename std::add_rvalue_reference<T>::type>
 cast_op(make_caster<T> &&caster) {


### PR DESCRIPTION
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->

Line 55 in cast.h produced a compilation error using gcc 12.1
Fixed the line of code according to this [stackoverflow answer](https://stackoverflow.com/a/19055844/2224647)

## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
